### PR TITLE
Add open console button, remove vm image header

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -5,7 +5,7 @@
 	var depends = [ "ngRoute", "esxiApp.filters", "esxiApp.services", "esxiApp.directives", "esxiApp.controllers" ];
 	// Declare app level module which depends on filters, and services
 	var app = angular.module("esxiApp", depends);
-	app.config([ "$routeProvider", function($routeProvider) {
+	app.config([ "$routeProvider", "$compileProvider", function($routeProvider, $compileProvider) {
 		$routeProvider.when("/", {
 			templateUrl : "partials/home.html",
 			controller : "HomeController"
@@ -23,6 +23,8 @@
 		$routeProvider.otherwise({
 			redirectTo : "/"
 		});
+		
+		$compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|ftp|mailto|vmrc):/);
 	} ]);
 
 	// REPLACING BROKEN IMAGES WITH A 1x1 GIF

--- a/web/js/controllers.js
+++ b/web/js/controllers.js
@@ -178,9 +178,11 @@
 		};
 	} ]);
 
-	module.controller("VmController", [ "$scope", "$routeParams", "esxApi", "$rootScope", function($scope, $routeParams, esxApi, $rootScope) {
+	module.controller("VmController", [ "$scope", "$routeParams", "esxApi", "hostname", "$rootScope", function($scope, $routeParams, esxApi, hostname, $rootScope) {
+	
 		var vmId = $routeParams.id;
 		$scope.id = vmId;
+		$scope.hostname = hostname;
 
 		var refreshInterval = 30, timer = null, isRefreshing = false;
 

--- a/web/partials/vm.html
+++ b/web/partials/vm.html
@@ -1,11 +1,11 @@
 <h3>
 	<i class="icon icon-desktop {{info.runtime.powerState}}"></i> {{info.config.name || 'Loading...'}}
 </h3>
-<div class="row">
+<!--div class="row">
 	<div class="screenshot-wrapper">
 		<img data-ng-src="/screen?id={{id}}&time={{refreshtime}}" data-ng-if="info.runtime.powerState == 'poweredOn'" />
 	</div>
-</div>
+</div-->
 <div class="row">
 	<div class="col-md-12">
 		<h4>State: {{info.runtime.powerState | camelcaseToSpace | ucwords}}</h4>
@@ -24,6 +24,9 @@
 		</a>
 		<a href="" class="btn btn-danger" data-ng-if="info.runtime.powerState && info.runtime.powerState == 'poweredOn'" data-ng-click="powerOff(info)"data-prevent-default="">
 			<i class="icon-power-off"></i> Power Off
+		</a>
+		<a href="vmrc://{{hostname}}/?moid={{id}}" class="btn btn-primary" data-ng-if="info.runtime.powerState && info.runtime.powerState == 'poweredOn'">
+			<i class="glyphicon glyphicon-new-window"></i> Open Console
 		</a>
 	</div>
 	<div class="col-md-2 text-right">


### PR DESCRIPTION
Adds a button to the vm screen to open the VM Remote Console application (http://www.vmware.com/go/download-vmrc) and removes the vm screenshot, as the second login and the bouncing were annoying.